### PR TITLE
Use HTTPS where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 A tool to create customized OpenStreetMap quality assurance feeds.
 
 Currently supported feed providers:
-* [OSM notes](http://wiki.openstreetmap.org/wiki/Notes)
-* [whodidit](http://wiki.openstreetmap.org/wiki/Quality_assurance#WhoDidIt)
-* [newestosm](http://neis-one.org/2012/07/new-contributor-feed/)
-* [KeepRight!](http://wiki.openstreetmap.org/wiki/Keepright)
-* [Osmose QA](http://wiki.openstreetmap.org/wiki/Osmose)
-* [(GB only) OS Locator Musical Chairs](http://wiki.openstreetmap.org/wiki/OS_Locator_Musical_Chairs)
+* [OSM notes](https://wiki.openstreetmap.org/wiki/Notes)
+* [whodidit](https://wiki.openstreetmap.org/wiki/Quality_assurance#WhoDidIt)
+* [newestosm](https://neis-one.org/2012/07/new-contributor-feed/)
+* [KeepRight!](https://wiki.openstreetmap.org/wiki/Keepright)
+* [Osmose QA](https://wiki.openstreetmap.org/wiki/Osmose)
+* [(GB only) OS Locator Musical Chairs](https://wiki.openstreetmap.org/wiki/OS_Locator_Musical_Chairs)

--- a/index.html
+++ b/index.html
@@ -94,44 +94,44 @@
       {
         label: "OSM notes",
         note: "User generated bug reports from osm.org.",
-        docUrl: "http://wiki.openstreetmap.org/wiki/Notes",
-        feedUrl: "http://www.openstreetmap.org/api/0.6/notes/feed?bbox={lon1},{lat1},{lon2},{lat2}"
+        docUrl: "https://wiki.openstreetmap.org/wiki/Notes",
+        feedUrl: "https://www.openstreetmap.org/api/0.6/notes/feed?bbox={lon1},{lat1},{lon2},{lat2}"
       },
       {
         label: "WhoDidIt",
         note: "Lists changesets that affect the watched region.",
-        docUrl: "http://wiki.openstreetmap.org/wiki/Quality_assurance#WhoDidIt",
-        feedUrl: "http://simon04.dev.openstreetmap.org/whodidit/scripts/rss.php?bbox={lon1},{lat1},{lon2},{lat2}"
+        docUrl: "https://wiki.openstreetmap.org/wiki/Quality_assurance#WhoDidIt",
+        feedUrl: "https://simon04.dev.openstreetmap.org/whodidit/scripts/rss.php?bbox={lon1},{lat1},{lon2},{lat2}"
       },
       {
         label: "newestosm",
         note: "Lists new contributors.",
-        docUrl: "http://neis-one.org/2012/04/where-are-the-new-openstreetmap-contributors/",
-        feedUrl: "http://resultmaps.neis-one.org/newestosmfeed.php?lon={lonc}&lat={latc}&deg={delta_deg}"
+        docUrl: "https://neis-one.org/2012/04/where-are-the-new-openstreetmap-contributors/",
+        feedUrl: "https://resultmaps.neis-one.org/newestosmfeed.php?lon={lonc}&lat={latc}&deg={delta_deg}"
       },
       {
         label: "Review requests",
         note: "Changesets where OSM contributors have asked for a review of their work.",
-        docUrl: "http://neis-one.org/2017/09/review-requests-osm/",
+        docUrl: "https://neis-one.org/2017/09/review-requests-osm/",
 	feedUrl: "https://resultmaps.neis-one.org/osm-suspicious-feed-bbox?hours=96&mappingdays=-1&tsearch=review_requested%3Dyes&anyobj=t&bbox={lon1},{lat1},{lon2},{lat2}"
       },
       {
         label: "KeepRight!",
         note: "Reports a large variety of automatically detected errors.",
-        docUrl: "http://wiki.openstreetmap.org/wiki/Keepright",
+        docUrl: "https://wiki.openstreetmap.org/wiki/Keepright",
         feedUrl: "http://keepright.ipax.at/export.php?format=rss&ch=0,30,40,50,70,90,100,110,120,130,150,160,170,180,191,192,193,194,195,196,197,198,201,202,203,204,205,206,207,208,210,220,231,232,270,281,282,283,284,285,291,292,293,294,311,312,313,320,350,370,380,401,402,411,412,413&left={lon1}&bottom={lat1}&right={lon2}&top={lat2}"
       },
       {
         label: "Osmose QA",
         note: "General quality assurance hints and warnings.",
-        docUrl: "http://wiki.openstreetmap.org/wiki/Osmose",
+        docUrl: "https://wiki.openstreetmap.org/wiki/Osmose",
         feedUrl: "http://osmose.openstreetmap.fr/en/errors.rss?item=xxxx&level=1%2C2&tags=&fixable=&bbox={lon1},{lat1},{lon2},{lat2}"
       },
       {
         label: "(GB only) OS Locator Musical Chairs",
-        note: "Great Britain only: highlights disagreements between <a href=\"http://wiki.openstreetmap.org/wiki/OS_Locator\">Ordnance Survey Opendata</a> and OSM.",
-        docUrl: "http://wiki.openstreetmap.org/wiki/OS_Locator_Musical_Chairs",
-        feedUrl: "http://ris.dev.openstreetmap.org/oslmusicalchairs/rss/relevant_downgrades?bbox={lon1},{lat1},{lon2},{lat2}",
+        note: "Great Britain only: highlights disagreements between <a href=\"https://wiki.openstreetmap.org/wiki/OS_Locator\">Ordnance Survey Opendata</a> and OSM.",
+        docUrl: "https://wiki.openstreetmap.org/wiki/OS_Locator_Musical_Chairs",
+        feedUrl: "https://ris.dev.openstreetmap.org/oslmusicalchairs/rss/relevant_downgrades?bbox={lon1},{lat1},{lon2},{lat2}",
         countryCodes: ["gb"]
       }
       // add more qa tools here:


### PR DESCRIPTION
Thanks for making this! I noticed that it’s generating feed links that use HTTP where HTTPS is now available. Hope this is helpful.